### PR TITLE
Removed broken/missing import & texture fix

### DIFF
--- a/src/main/java/bernie/software/ModEventSubscriber.java
+++ b/src/main/java/bernie/software/ModEventSubscriber.java
@@ -4,7 +4,6 @@ import bernie.software.client.renderer.model.*;
 import bernie.software.registry.DeepWatersContainerTypes;
 import bernie.software.client.renderer.tileentity.renderer.aquafan;
 import bernie.software.gui.VehicleContainer;
-import bernie.software.gui.VehicleContainerTypes;
 import bernie.software.gui.surge.SurgeScreen;
 import bernie.software.registry.DeepWatersEntities;
 import bernie.software.registry.DeepWatersStructures;

--- a/src/main/resources/assets/deepwaters/models/block/oxygenator.json
+++ b/src/main/resources/assets/deepwaters/models/block/oxygenator.json
@@ -6,6 +6,7 @@
     "north": "deepwaters:block/oxygenator",
     "east": "deepwaters:block/oxygenator_sides",
     "south": "deepwaters:block/oxygenator_sides",
-    "west": "deepwaters:block/oxygenator_sides"
+    "west": "deepwaters:block/oxygenator_sides",
+    "particle": "deepwaters:block/oxygenator_sides"
   }
 }


### PR DESCRIPTION
`VehicleContainerTypes` no longer exists, I assume its been shifted to `DeepWatersContainerTypes`. 

Either way, the import causes an unknown symbol error on build.

Likely the cause of your recent failed build, https://tincrayon.visualstudio.com/DeepWaters/_build/results?buildId=199&view=results

Also added a break particle to the Oxygenator. neat.